### PR TITLE
fix: Fix for fix

### DIFF
--- a/pkg/universe.dagger.io/x/solomon@dagger.io/spectral/lint.cue
+++ b/pkg/universe.dagger.io/x/solomon@dagger.io/spectral/lint.cue
@@ -105,10 +105,14 @@ import (
 	container: docker.#Run & {
 		// Default container image can be overrided.
 		//   'spectral' must be installed and in the PATH.
-		input:              docker.#Image | *_buildDefaultImage.output
-		_buildDefaultImage: docker.#Pull & {
-			source: "stoplight/spectral"
+		input: docker.#Image
+		if input == _|_ {
+			_input: docker.#Pull & {
+				source: "stoplight/spectral"
+			}
+			input: _input.output
 		}
+
 		// Ugly hack to override the entrypoint from the default image
 		//  FIXME: how do we tuck this into the scope of the default image?
 		entrypoint: []

--- a/pkg/universe.dagger.io/x/solomon@dagger.io/spectral/lint.cue
+++ b/pkg/universe.dagger.io/x/solomon@dagger.io/spectral/lint.cue
@@ -103,15 +103,13 @@ import (
 
 	// Setup a Docker container to run the spectral CLI
 	container: docker.#Run & {
-		// Default container image can be overrided.
-		//   'spectral' must be installed and in the PATH.
+		// specify container image to use in calling plan
+		// by building an image or using an existing
+		// image with 'spectral' installed and in PATH.
+		// e.g. (see test/test.cue)
+		// container: input: _pull.output
+		// _pull: docker.#Pull & {source: "stoplight/spectral"}
 		input: docker.#Image
-		if input == _|_ {
-			_input: docker.#Pull & {
-				source: "stoplight/spectral"
-			}
-			input: _input.output
-		}
 
 		// Ugly hack to override the entrypoint from the default image
 		//  FIXME: how do we tuck this into the scope of the default image?

--- a/pkg/universe.dagger.io/x/solomon@dagger.io/spectral/test/test.cue
+++ b/pkg/universe.dagger.io/x/solomon@dagger.io/spectral/test/test.cue
@@ -3,6 +3,7 @@ package spectral
 import (
 	"dagger.io/dagger"
 	"dagger.io/dagger/core"
+	"universe.dagger.io/docker"
 )
 
 dagger.#Plan & {
@@ -22,6 +23,8 @@ dagger.#Plan & {
 				source: _data.contents
 				ruleset: filename: "standards.spectral.yaml"
 				documents: ["petstore.yaml"]
+				container: input: _pull.output
+				_pull: docker.#Pull & {source: "stoplight/spectral"}
 			}
 			// Test assertion
 			nMessages: len(lint.logs) & 15


### PR DESCRIPTION
This commit makes `container: input:` required in the calling Dagger plan (type `docker.#Image`), adds comments to explain and suggest an image in `spectral.#Lint` and uses `stoplight/spectral` in the test example. The default approach we were taking in `spectral.#Lint` doesn't work at the moment if there is no `container: input:` provided, so we make this explicit.